### PR TITLE
feat: Hide Documentation and About sections from nav bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ const App = () => (
             <main className="flex-1">
               <Routes>
                 <Route path="/" element={<Home />} />
-                <Route path="/about" element={<About />} />
+                {/* <Route path="/about" element={<About />} /> */}
                 <Route path="/features" element={<Features />} />
                 <Route path="/demo" element={<Demo />} />
                 {/* <Route path="/docs" element={<Documentation />} /> */}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,10 +11,10 @@ export const Navigation = () => {
 
   const navigation = [
     { name: "Home", href: "/", icon: FileText },
-    { name: "About", href: "/about", icon: Users },
+    // { name: "About", href: "/about", icon: Users },
     { name: "Features", href: "/features", icon: Zap },
     { name: "Demo", href: "/demo", icon: Play },
-    { name: "Documentation", href: "/docs", icon: Book },
+    // { name: "Documentation", href: "/docs", icon: Book },
     { name: "Contact", href: "/contact", icon: Mail },
     ...(user ? [{ name: "Logs", href: "/logs", icon: Activity }] : []),
   ];


### PR DESCRIPTION
This commit hides the "Documentation" and "About" sections from the navigation bar by commenting out the corresponding links in `Navigation.tsx` and routes in `App.tsx`.

This approach was taken based on user feedback to allow for easy re-enabling of these sections in the future.